### PR TITLE
update bootstrap url to use .com

### DIFF
--- a/.kitchen-docker.yml
+++ b/.kitchen-docker.yml
@@ -6,6 +6,7 @@ driver:
 provisioner:
   name: salt_solo
   formula: rundeck
+  salt_bootstrap_url: 'https://bootstrap.saltstack.com'
   state_top:
     base:
       "*":

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ driver:
 provisioner:
   name: salt_solo
   formula: rundeck
+  salt_bootstrap_url: 'https://bootstrap.saltstack.com'
   state_top:
     base:
       "*":


### PR DESCRIPTION
workaround until https://github.com/saltstack/kitchen-salt/pull/116 is merged.